### PR TITLE
update structure of CELERY_TOKEN_BUCKETS config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A dynamic [token bucket](https://medium.com/analytics-vidhya/celery-throttling-setting-rate-limit-for-queues-5b5bf16c73ce) implementation using the database scheduler [django celery beat](https://github.com/celery/django-celery-beat).
 
-## How it Works
+## How it works
 
-The bucket is represented by a celery queue that will not be processed by a worker but just hold our tokens (messages). 
+The bucket is represented by a celery queue that will not be processed by a worker but just hold our tokens (messages).
 Whenever a rate limited task should be run, the decorator tries to consume a message from that queue. If the queue is empty, the task gets retried after the defined timeout.  
 A periodic task will then refill the bucket with tokens whenever they should be available again.
 
@@ -15,6 +15,7 @@ Buckets are defined in the Django config.
 Following example allows one thousand tokens per hour to throttle access to a rate limited third party API.
 
 Add to `settings.py` of your project.
+
 ```python
 from typing import Dict
 from celery import schedules
@@ -37,8 +38,8 @@ CELERY_TOKEN_BUCKETS: Dict[str, TokenBucket] = {
 
 ### name
 
-The name must only consist of letters, numbers and the underscore character as it's used in the name of the celery queue.
-It should also be the same as the key in the CELERY_TOKEN_BUCKETS dictionary.
+The name must only consist of letters, numbers and the underscore character as it's used in the name of the celery
+queue. It should also be the same as the key in the CELERY_TOKEN_BUCKETS dictionary.
 
 ### schedule
 
@@ -54,7 +55,8 @@ The maximum amount of tokens our bucket can hold.
 
 ## Sync period tasks to refill the buckets
 
-A management command `token_bucket_register_periodic_tasks` is provided that should be run during deployment of your application to sync the period tasks and make sure that buckets get properly refilled.
+A management command `token_bucket_register_periodic_tasks` is provided that should be run during deployment of your
+application to sync the period tasks and make sure that buckets get properly refilled.
 
 ## Use the rate_limit decorator
 
@@ -64,13 +66,15 @@ The decorator will make sure that the task that gets decorated will not exceed t
 from my_app.celery import celery_app
 from django_celery_token_bucket.decorators import rate_limit
 
+
 @celery_app.task
 @rate_limit(token_bucket="my_api_client", retry_backoff=300)
 def my_tasK(*args, **kwargs):
     return
 ```
 
-The above task will try to consume a token from the `my_api_client` and retries after 300 seconds if no token is available.
+The above task will try to consume a token from the `my_api_client` and retries after 300 seconds if no token is
+available.
 
 ## Run the tests locally
 
@@ -85,7 +89,9 @@ docker-compose run --rm django test
 [bumpversion](https://github.com/peritus/bumpversion) is used to manage releases.
 
 Add your changes to the [CHANGELOG](./CHANGELOG.md), run
+
 ```bash
 bumpversion <major|minor|patch>
 ```
+
 and push (including tags).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A dynamic [token bucket](https://medium.com/analytics-vidhya/celery-throttling-setting-rate-limit-for-queues-5b5bf16c73ce) implementation using the database scheduler [django celery beat](https://github.com/celery/django-celery-beat).
 
-## How it's working
+## How it Works
 
 The bucket is represented by a celery queue that will not be processed by a worker but just hold our tokens (messages). 
 Whenever a rate limited task should be run, the decorator tries to consume a message from that queue. If the queue is empty, the task gets retried after the defined timeout.  
@@ -16,24 +16,29 @@ Following example allows one thousand tokens per hour to throttle access to a ra
 
 Add to `settings.py` of your project.
 ```python
-from typing import List
-
+from typing import Dict
+from celery import schedules
 from django_celery_token_bucket import TokenBucket
 
+INSTALLED_APPS = [
+    ...,
+    'django_celery_token_bucket'
+]
 
-CELERY_TOKEN_BUCKETS: List[TokenBucket] = [
-    TokenBucket(
+CELERY_TOKEN_BUCKETS: Dict[str, TokenBucket] = {
+    "my_api_client": TokenBucket(
         name="my_api_client",
         schedule=schedules.crontab(minute=0),  # once every hour
         amount=1000,
         maximum=1000,
-    ),
-]
+    )
+}
 ```
 
 ### name
 
 The name must only consist of letters, numbers and the underscore character as it's used in the name of the celery queue.
+It should also be the same as the key in the CELERY_TOKEN_BUCKETS dictionary.
 
 ### schedule
 

--- a/django_celery_token_bucket/bucket.py
+++ b/django_celery_token_bucket/bucket.py
@@ -44,7 +44,7 @@ class TokenBucket:
             defaults=dict(
                 queue="token_bucket",
                 kwargs=json.dumps(dict(name=self.name)),
-                task="celery_token_bucket.tasks.token_bucket_refill",
+                task="django_celery_token_bucket.tasks.token_bucket_refill",
                 interval=None,
                 crontab=crontabschedule,
             ),

--- a/django_celery_token_bucket/decorators.py
+++ b/django_celery_token_bucket/decorators.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from functools import wraps
 from queue import Empty
-from bucket import TokenBucket
+from django_celery_token_bucket.bucket import TokenBucket
 
 
 def rate_limit(token_bucket_name: str, retry_backoff: int = 60):

--- a/django_celery_token_bucket/decorators.py
+++ b/django_celery_token_bucket/decorators.py
@@ -1,15 +1,24 @@
+from django.conf import settings
 from functools import wraps
 from queue import Empty
+from bucket import TokenBucket
 
 
-def rate_limit(token_bucket: str, retry_backoff: int = 60):
+def rate_limit(token_bucket_name: str, retry_backoff: int = 60):
     def decorator_func(func):
         @wraps(func)
         def function(self, *args, **kwargs):
             with self.app.connection_for_read() as conn:
-                with conn.SimpleQueue(token_bucket, no_ack=True) as queue:
+                queue_name = f"{TokenBucket.QUEUE_PREFIX}{token_bucket_name}"
+                try:
+                    token_bucket: TokenBucket = settings.CELERY_TOKEN_BUCKETS[token_bucket_name]
+                except KeyError:
+                    raise Exception(f"bucket '{token_bucket_name}' is not registered")
+
+                with conn.SimpleQueue(queue_name, queue_opts={'max_length': token_bucket.maximum}) as queue:
                     try:
-                        queue.get(block=True, timeout=5)
+                        message = queue.get(block=True, timeout=5)
+                        message.ack()
                         return func(self, *args, **kwargs)
                     except Empty:
                         self.retry(countdown=retry_backoff)

--- a/django_celery_token_bucket/decorators.py
+++ b/django_celery_token_bucket/decorators.py
@@ -1,6 +1,8 @@
-from django.conf import settings
 from functools import wraps
 from queue import Empty
+
+from django.conf import settings
+
 from django_celery_token_bucket.bucket import TokenBucket
 
 
@@ -9,9 +11,9 @@ def rate_limit(token_bucket_name: str, retry_backoff: int = 60):
         @wraps(func)
         def function(self, *args, **kwargs):
             with self.app.connection_for_read() as conn:
-                queue_name = f"{TokenBucket.QUEUE_PREFIX}{token_bucket_name}"
                 try:
                     token_bucket: TokenBucket = settings.CELERY_TOKEN_BUCKETS[token_bucket_name]
+                    queue_name = token_bucket.get_queue_name()
                 except KeyError:
                     raise Exception(f"bucket '{token_bucket_name}' is not registered")
 

--- a/django_celery_token_bucket/management/commands/token_bucket_register_periodic_tasks.py
+++ b/django_celery_token_bucket/management/commands/token_bucket_register_periodic_tasks.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         token_bucket: TokenBucket
-        for token_bucket in settings.CELERY_TOKEN_BUCKETS:
+        for _, token_bucket in settings.CELERY_TOKEN_BUCKETS.items():
             # add a periodic task to our main queue to refill the tokens
             token_bucket.create_periodic_task()
             logging.info(

--- a/django_celery_token_bucket/tests/test_bucket.py
+++ b/django_celery_token_bucket/tests/test_bucket.py
@@ -52,7 +52,7 @@ class TokenBucketTestCase(TestCase):
             defaults=dict(
                 queue="token_bucket",
                 kwargs='{"name": "my_custom_api"}',
-                task="celery_token_bucket.tasks.token_bucket_refill",
+                task="django_celery_token_bucket.tasks.token_bucket_refill",
                 interval=None,
                 crontab=token_bucket_get_or_create_schedule_return_value,
             ),

--- a/docker/settings.py
+++ b/docker/settings.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List
+from typing import Dict
 import os
 
 from celery import schedules
@@ -76,17 +76,17 @@ USE_TZ = True
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-CELERY_TOKEN_BUCKETS: List[TokenBucket] = [
-    TokenBucket(
+CELERY_TOKEN_BUCKETS: Dict[str, TokenBucket] = {
+    "my_custom_api": TokenBucket(
         name="my_custom_api",
         schedule=schedules.crontab(minute=0),  # once every hour
         amount=10,
         maximum=10,
     ),
-    TokenBucket(
+    "another_bucket": TokenBucket(
         name="another_bucket",
         schedule=schedules.crontab(minute=30, hour=3),  # 3:30am
         amount=10,
         maximum=100,
-    ),
-]
+    )
+}


### PR DESCRIPTION
The following changes were made in this PR

- fixed the name of the periodic task generated for each token bucket
- updated the structure of the CELERY_TOKEN_BUCKETS from a list to dictionary for quick and cleaner lookups
- updated the README