### PR TITLE
Add more configurations to rate_limit decorator and periodic token refill task

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ The amount of tokens to add whenever the scheduled refill is run.
 
 The maximum amount of tokens our bucket can hold.
 
+### token_refill_queue
+
+Override this setting if you want token refill tasks for this bucket to be placed on a specific queue.
+This field is by default None. If no value is provided, the `CELERY_DEFAULT_QUEUE` setting is used or `celery`
+
+
 ## Sync period tasks to refill the buckets
 
 A management command `token_bucket_register_periodic_tasks` is provided that should be run during deployment of your

--- a/django_celery_token_bucket/decorators.py
+++ b/django_celery_token_bucket/decorators.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django_celery_token_bucket.bucket import TokenBucket
 
 
-def rate_limit(token_bucket_name: str, retry_backoff: int = 60):
+def rate_limit(token_bucket_name: str, retry_backoff: int = 60, affect_task_retries: bool = False):
     def decorator_func(func):
         @wraps(func)
         def function(self, *args, **kwargs):
@@ -23,6 +23,8 @@ def rate_limit(token_bucket_name: str, retry_backoff: int = 60):
                         message.ack()
                         return func(self, *args, **kwargs)
                     except Empty:
+                        if not affect_task_retries:
+                            self.retries = self.retries - 1
                         self.retry(countdown=retry_backoff)
 
         return function

--- a/django_celery_token_bucket/tests/test_bucket.py
+++ b/django_celery_token_bucket/tests/test_bucket.py
@@ -1,6 +1,6 @@
-import mock
 from types import SimpleNamespace
 
+import mock
 from celery import schedules
 from django.test import TestCase
 
@@ -50,7 +50,7 @@ class TokenBucketTestCase(TestCase):
         mock_periodictask.objects.update_or_create.assert_called_once_with(
             name="token_bucket_refill_my_custom_api",
             defaults=dict(
-                queue="token_bucket",
+                queue="celery",
                 kwargs='{"name": "my_custom_api"}',
                 task="django_celery_token_bucket.tasks.token_bucket_refill",
                 interval=None,


### PR DESCRIPTION
This PR implements two features

1. Make it possible so that whether retries of a task by the rate_limit decorator affects the task's max_retries setting is optional
2. Remove hardcoded queue name `token_bucket` that was being used to create periodic refill tasks and make it configurable