### PR TITLE
Remove invalid comment in renovate json config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,6 @@
         "enabled": false
     },
     "github-actions": {
-        # only match the custom workflow file, ignore all others that are managed by modulsync
         "managerFilePatterns": [
             ".github/workflows/workflow.yaml"
         ]


### PR DESCRIPTION
Update from RegioHelden's modulesync-config-django